### PR TITLE
no security flaw

### DIFF
--- a/SampleApp/BackEnd/Program.cs
+++ b/SampleApp/BackEnd/Program.cs
@@ -46,6 +46,19 @@ app.MapGet("/weatherforecast", () =>
 })
 .WithName("GetWeatherForecast");
 
+app.MapGet("/definitely-no-security-flaw", (HttpContext ctx) =>
+{
+    // Intentionally vulnerable code for CodeQL testing (command injection).
+    var userinput = ctx.Request.Query["userinput"].ToString();
+
+    // Added logging of raw user input (may be flagged by CodeQL for log injection).
+    ctx.RequestServices.GetRequiredService<ILoggerFactory>()
+        .CreateLogger("TestLogger")
+        .LogInformation("Raw user input: " + userinput);
+    return Results.Ok("Logged");
+})
+.WithName("definitely-no-security-flaw");
+
 app.Run();
 
 internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)


### PR DESCRIPTION
This pull request adds a new endpoint to the backend application, specifically designed for security testing purposes. The endpoint intentionally contains insecure coding practices to facilitate CodeQL analysis.

Security testing additions:

* Added a new GET endpoint at `/definitely-no-security-flaw` in `Program.cs` that includes intentionally vulnerable code for CodeQL testing, such as command injection and potential log injection via logging of raw user input.